### PR TITLE
Update Figshare download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ backgrounds. The MOB-suite is designed to be a modular set of tools for the typi
 reconstruction of plasmid sequences from WGS assemblies.
 
 The MOB-suite depends on a series of databases which are too large to be hosted in git-hub. They can be downloaded or updated by running mob_init or if running any of the tools for the first time, the databases will download and initialize automatically. However, they are quite large so the first run will take a long time depending on your connection and speed of your computer.
-The databases can be downloaded from figshare here: https://ndownloader.figshare.com/articles/5841882?private_link=a4c92dd84f17b2cefea6
+The databases can be downloaded from figshare here: https://ndownloader.figshare.com/articles/5841882/versions/1
 
 ### MOB-init
 On first run of MOB-typer or MOB-recon, MOB-init should run to download the databases from figshare, sketch the databases and setup the blast databases. However, it can be run manually if the databases need to be re-initialized.

--- a/mob_suite/mob_init.py
+++ b/mob_suite/mob_init.py
@@ -67,7 +67,7 @@ def main():
     repetitive_fasta_file = os.path.join(database_directory,'repetitive.dna.fas')
     mash_db_file =  os.path.join(database_directory,'ncbi_plasmid_full_seqs.fas.msh')
     logging.info('Downloading databases...this will take some time')
-    download_to_file('https://ndownloader.figshare.com/articles/5841882?private_link=a4c92dd84f17b2cefea6',zip_file)
+    download_to_file('https://ndownloader.figshare.com/articles/5841882/versions/1', zip_file)
     if (not os.path.isfile(zip_file)):
         logging.error('Downloading databases failed, please check your internet connection and retry')
         sys.exit(-1)


### PR DESCRIPTION
Looks like the download link that `mob_init` used isn't working any more - I've updated the link to a working version.

@jamespocalypse 
@kbessonov1984  