### PR TITLE
Allow databases to be downloaded to other locations

### DIFF
--- a/mob_suite/blast/__init__.py
+++ b/mob_suite/blast/__init__.py
@@ -127,7 +127,7 @@ class BlastReader:
         self.blast_outfile = blast_outfile
         try:
 
-            self.df = pd.read_table(self.blast_outfile, header=None)
+            self.df = pd.read_csv(self.blast_outfile, header=None, delimiter='\t')
             self.df.columns = BLAST_TABLE_COLS
 
             logging.debug(self.df.head())

--- a/mob_suite/mob_init.py
+++ b/mob_suite/mob_init.py
@@ -32,7 +32,6 @@ def download_to_file(url,file):
         c.close()
 
 def extract(fname,outdir):
-    print(fname, outdir)
     if (fname.endswith("tar.gz")):
         tar = tarfile.open(fname, "r:gz")
         tar.extractall()

--- a/mob_suite/mob_init.py
+++ b/mob_suite/mob_init.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from mob_suite.version import __version__
 import os, pycurl, tarfile, zipfile, gzip, multiprocessing, sys
+import argparse
 from mob_suite.blast import BlastRunner
 from mob_suite.wrappers import mash
 from os import listdir
@@ -31,6 +32,7 @@ def download_to_file(url,file):
         c.close()
 
 def extract(fname,outdir):
+    print(fname, outdir)
     if (fname.endswith("tar.gz")):
         tar = tarfile.open(fname, "r:gz")
         tar.extractall()
@@ -53,6 +55,12 @@ def extract(fname,outdir):
             os.remove(fname)
 
 def main():
+    default_database_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--database_directory',
+                        default=default_database_dir,
+                        help='Directory to download databases to. Defaults to {}'.format(default_database_dir))
+    args = parser.parse_args()
     logging = init_console_logger(2)
     logging.info('Initilizating databases...this will take some time')
 
@@ -61,7 +69,10 @@ def main():
     if num_threads > 32:
         num_threads = 32
 
-    database_directory = os.path.join(os.path.dirname(os.path.realpath(__file__)),'databases/')
+    # For some reason absolute paths don't work - enforce absolute path.
+    database_directory = os.path.abspath(args.database_directory)
+    if not os.path.exists(database_directory):
+        os.makedirs(database_directory)
     zip_file = os.path.join(database_directory,'data.zip')
     plasmid_database_fasta_file = os.path.join(database_directory,'ncbi_plasmid_full_seqs.fas')
     repetitive_fasta_file = os.path.join(database_directory,'repetitive.dna.fas')

--- a/mob_suite/mob_recon.py
+++ b/mob_suite/mob_recon.py
@@ -113,7 +113,7 @@ def parse_args():
     parser.add_argument('--plasmid_mob', type=str, required=False, help='Fasta of plasmid relaxases',
                         default=os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                              'databases/mob.proteins.faa'))
-    parser.add_argument('--database_dir',
+    parser.add_argument('-d', '--database_directory',
                         default=default_database_dir,
                         required=False,
                         help='Directory you want to use for your databases. If the databases are not already '
@@ -166,7 +166,7 @@ def run_mob_typer(fasta_path, outdir, num_threads=1, database_dir=None):
                    '--infile', fasta_path,
                    '--outdir', outdir,
                    '--keep_tmp',
-                   '--database_dir', database_dir,
+                   '--database_directory', database_dir,
                    '--num_threads', str(num_threads)],
                   stdout=PIPE,
                   stderr=PIPE)
@@ -301,7 +301,7 @@ def main():
         os.mkdir(args.outdir, 0o755)
 
     # Check that the needed databases have been initialized
-    database_dir = os.path.abspath(args.database_dir)
+    database_dir = os.path.abspath(args.database_directory)
     verify_init(logging, database_dir)
     status_file = os.path.join(database_dir, 'status.txt')
 

--- a/mob_suite/mob_recon.py
+++ b/mob_suite/mob_recon.py
@@ -28,6 +28,7 @@ LOG_FORMAT = '%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d
 
 def parse_args():
     "Parse the input arguments, use '-h' for help"
+    default_database_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases')
     parser = ArgumentParser(
         description="Mob Suite: Typing and reconstruction of plasmids from draft and complete assemblies version: {}".format(
             __version__))
@@ -112,6 +113,11 @@ def parse_args():
     parser.add_argument('--plasmid_mob', type=str, required=False, help='Fasta of plasmid relaxases',
                         default=os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                              'databases/mob.proteins.faa'))
+    parser.add_argument('--database_dir',
+                        default=default_database_dir,
+                        required=False,
+                        help='Directory you want to use for your databases. If the databases are not already '
+                             'downloaded, they will be downloaded automatically. Defaults to {}'.format(default_database_dir))
 
     return parser.parse_args()
 
@@ -145,15 +151,25 @@ def mcl_predict(blast_results_file, min_ident, min_cov, evalue, min_length, tmp_
     return mcl_clusters
 
 
-def run_mob_typer(fasta_path, outdir, num_threads=1):
+def run_mob_typer(fasta_path, outdir, num_threads=1, database_dir=None):
     mob_typer_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mob_typer.py')
-    p = Popen(['python', mob_typer_path,
-               '--infile', fasta_path,
-               '--outdir', outdir,
-               '--keep_tmp',
-               '--num_threads', str(num_threads)],
-              stdout=PIPE,
-              stderr=PIPE)
+    if database_dir is None:
+        p = Popen(['python', mob_typer_path,
+                   '--infile', fasta_path,
+                   '--outdir', outdir,
+                   '--keep_tmp',
+                   '--num_threads', str(num_threads)],
+                  stdout=PIPE,
+                  stderr=PIPE)
+    else:
+        p = Popen(['python', mob_typer_path,
+                   '--infile', fasta_path,
+                   '--outdir', outdir,
+                   '--keep_tmp',
+                   '--database_dir', database_dir,
+                   '--num_threads', str(num_threads)],
+                  stdout=PIPE,
+                  stderr=PIPE)
     p.wait()
     stdout = p.stdout.read()
     stderr = p.stderr.read()
@@ -285,8 +301,9 @@ def main():
         os.mkdir(args.outdir, 0o755)
 
     # Check that the needed databases have been initialized
-    verify_init(logging)
-    status_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases/status.txt')
+    database_dir = os.path.abspath(args.database_dir)
+    verify_init(logging, database_dir)
+    status_file = os.path.join(database_dir, 'status.txt')
 
 
     if not os.path.isfile(status_file):
@@ -416,11 +433,20 @@ def main():
     min_length = args.min_length
 
     # Input Databases
-    plasmid_ref_db = args.plasmid_db
-    replicon_ref = args.plasmid_replicons
-    mob_ref = args.plasmid_mob
-    mash_db = args.plasmid_mash_db
-    repetitive_mask_file = args.repetitive_mask
+    default_database_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases')
+    if database_dir == default_database_dir:
+        plasmid_ref_db = args.plasmid_db
+        replicon_ref = args.plasmid_replicons
+        mob_ref = args.plasmid_mob
+        mash_db = args.plasmid_mash_db
+        repetitive_mask_file = args.repetitive_mask
+    else:
+        plasmid_ref_db = os.path.join(database_dir, 'ncbi_plasmid_full_seqs.fas')
+        replicon_ref = os.path.join(database_dir, 'rep.dna.fas')
+        mob_ref = os.path.join(database_dir, 'mob.proteins.faa')
+        mash_db = os.path.join(database_dir, 'ncbi_plasmid_full_seqs.fas.msh')
+        repetitive_mask_file = os.path.join(database_dir, 'repetitive.dna.fas')
+
 
     check_dependencies(logging)
 
@@ -763,7 +789,7 @@ def main():
                            "orit_type(s)\torit_accession(s)\tPredictedMobility\t" \
                            "mash_nearest_neighbor\tmash_neighbor_distance\tmash_neighbor_cluster\n"
         for file in plasmid_files:
-            mobtyper_results = mobtyper_results + "{}".format(run_mob_typer(file, out_dir, str(num_threads)))
+            mobtyper_results = mobtyper_results + "{}".format(run_mob_typer(file, out_dir, str(num_threads), database_dir=database_dir))
         fh = open(mobtyper_results_file, 'w')
         fh.write(mobtyper_results)
         fh.close()

--- a/mob_suite/mob_typer.py
+++ b/mob_suite/mob_typer.py
@@ -114,7 +114,7 @@ def parse_args():
     parser.add_argument('--plasmid_orit', type=str, required=False, help='Fasta of known plasmid oriT dna sequences',
                         default=os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                              'databases/orit.fas'))
-    parser.add_argument('--database_dir',
+    parser.add_argument('-d', '--database_directory',
                         default=default_database_dir,
                         required=False,
                         help='Directory you want to use for your databases. If the databases are not already '
@@ -160,7 +160,7 @@ def main():
     if not isinstance(args.num_threads, int):
         logging.info('Error number of threads must be an integer, you specified "{}"'.format(args.num_threads))
 
-    database_dir = os.path.abspath(args.database_dir)
+    database_dir = os.path.abspath(args.database_directory)
     verify_init(logging, database_dir)
     # Script arguments
     input_fasta = args.infile

--- a/mob_suite/mob_typer.py
+++ b/mob_suite/mob_typer.py
@@ -37,6 +37,7 @@ def init_console_logger(lvl):
 
 def parse_args():
     "Parse the input arguments, use '-h' for help"
+    default_database_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases')
     parser = ArgumentParser(
         description="Mob Suite: Typing and reconstruction of plasmids from draft and complete assemblies version: {}".format(
             __version__))
@@ -113,6 +114,14 @@ def parse_args():
     parser.add_argument('--plasmid_orit', type=str, required=False, help='Fasta of known plasmid oriT dna sequences',
                         default=os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                              'databases/orit.fas'))
+    parser.add_argument('--database_dir',
+                        default=default_database_dir,
+                        required=False,
+                        help='Directory you want to use for your databases. If the databases are not already '
+                             'downloaded, they will be downloaded automatically. Defaults to {}. '
+                             'If you change this from the default, will override --plasmid_mash_db, '
+                             '--plasmid_replicons, --plasmid_mob, --plasmid_mpf, and '
+                             '--plasmid_orit'.format(default_database_dir))
     return parser.parse_args()
 
 
@@ -128,6 +137,7 @@ def determine_mpf_type(hits):
 
 
 def main():
+    default_database_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases')
     args = parse_args()
     if args.debug:
         init_console_logger(3)
@@ -150,33 +160,42 @@ def main():
     if not isinstance(args.num_threads, int):
         logging.info('Error number of threads must be an integer, you specified "{}"'.format(args.num_threads))
 
-    verify_init(logging)
+    database_dir = os.path.abspath(args.database_dir)
+    verify_init(logging, database_dir)
     # Script arguments
     input_fasta = args.infile
     out_dir = args.outdir
     num_threads = int(args.num_threads)
     keep_tmp = args.keep_tmp
-    mob_ref = args.plasmid_mob
-    mpf_ref = args.plasmid_mpf
-    orit_ref = args.plasmid_orit
-    mash_db = args.plasmid_mash_db
+    if database_dir == default_database_dir:
+        mob_ref = args.plasmid_mob
+        mpf_ref = args.plasmid_mpf
+        orit_ref = args.plasmid_orit
+        mash_db = args.plasmid_mash_db
+        replicon_ref = args.plasmid_replicons
+    else:
+        mob_ref = os.path.join(database_dir, 'mob.proteins.faa')
+        mpf_ref = os.path.join(database_dir, 'mpf.proteins.faa')
+        orit_ref = os.path.join(database_dir, 'orit.fas')
+        mash_db = os.path.join(database_dir, 'ncbi_plasmid_full_seqs.fas.msh')
+        replicon_ref = os.path.join(database_dir, 'rep.dna.fas')
+
 
     tmp_dir = os.path.join(out_dir, '__tmp')
     file_id = os.path.basename(input_fasta)
     fixed_fasta = os.path.join(tmp_dir, 'fixed.input.fasta')
-    replicon_ref = args.plasmid_replicons
     replicon_blast_results = os.path.join(tmp_dir, 'replicon_blast_results.txt')
     mob_blast_results = os.path.join(tmp_dir, 'mobtyper_blast_results.txt')
     mpf_blast_results = os.path.join(tmp_dir, 'mpf_blast_results.txt')
     orit_blast_results = os.path.join(tmp_dir, 'orit_blast_results.txt')
     if os.path.isfile(mob_blast_results):
-    	os.remove(mob_blast_results)
+        os.remove(mob_blast_results)
     if os.path.isfile(mpf_blast_results):
-    	os.remove(mpf_blast_results)
+        os.remove(mpf_blast_results)
     if os.path.isfile(orit_blast_results):
-    	os.remove(orit_blast_results)    
+        os.remove(orit_blast_results)
     if os.path.isfile(replicon_blast_results):
-    	os.remove(replicon_blast_results)     	
+        os.remove(replicon_blast_results)
     report_file = os.path.join(out_dir, 'mobtyper_' + file_id + '_report.txt')
     mash_file = os.path.join(tmp_dir, 'mash_' + file_id + '.txt')
 

--- a/mob_suite/utils.py
+++ b/mob_suite/utils.py
@@ -57,12 +57,13 @@ def write_fasta_dict(seqs, fasta_file):
             handle.write(">{}\n{}\n".format(id, seqs[id]))
     handle.close()
 
-def verify_init(logging):
+
+def verify_init(logging, database_dir):
     mob_init_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mob_init.py')
-    status_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'databases/status.txt')
+    status_file = os.path.join(database_dir, 'status.txt')
     if not os.path.isfile(status_file):
         logging.info('MOB-databases need to be initialized, this will take some time')
-        p = Popen(['python', mob_init_path],
+        p = Popen(['python', mob_init_path, '-d', database_dir],
                   stdout=PIPE,
                   stderr=PIPE)
         p.wait()


### PR DESCRIPTION
Hi there,

This pull request adds a `--database_directory/-d` argument to `mob_init`, `mob_recon`, and `mob_typer` that allows for users to specify a location other than the default for `mob_suite` databases, which would be useful for us (we're running `mob_suite` from within docker, and want to try to keep the docker image as small as possible, so ideally we want the databases to be part of a mounted volume). If nothing gets specified, everything works the same as it did before.

Thanks,
Andrew
