### PR TITLE
Do not include filename in contig id in mob_recon output

### DIFF
--- a/mob_suite/utils.py
+++ b/mob_suite/utils.py
@@ -253,7 +253,7 @@ def fix_fasta_header(in_fasta, out_fasta):
     fh = open(out_fasta, 'w')
     with open(in_fasta, "r") as handle:
         for record in SeqIO.parse(handle, "fasta"):
-            fh.write(">" + str(in_basename) + "|" + str(record.description).replace(' ', '_') + "\n" + str(
+            fh.write(">" + str(record.description).replace(' ', '_') + "\n" + str(
                 record.seq) + "\n")
     handle.close()
     fh.close()


### PR DESCRIPTION
Fixes #11 

Removed `str(in_basename) + "|"` from `fix_fasta_header()` method.