### PR TITLE
fixed issue with mismatched mash sketch and clusters.txt

### DIFF
--- a/mob_suite/mob_typer.py
+++ b/mob_suite/mob_typer.py
@@ -413,6 +413,8 @@ def main():
             distances = OrderedDict(sorted(mash_results[seq_id].items(), key=itemgetter(1), reverse=False))
             mash_neighbor_id = next(iter(distances))
             dist = distances[mash_neighbor_id]
+            if mash_neighbor_id not in reference_sequence_meta:
+                continue
             record['mash_nearest_neighbor'] = mash_neighbor_id
             record['mash_neighbor_distance'] = dist
             record['primary_cluster_id'] = reference_sequence_meta[mash_neighbor_id]['primary_cluster_id']


### PR DESCRIPTION
If reference sequence is in mash sketch but not in the clusters file, causes a crash