### PR TITLE
handle missing blast results file

### DIFF
--- a/mob_suite/utils.py
+++ b/mob_suite/utils.py
@@ -1305,7 +1305,7 @@ def blast_mge(contig_fasta, mge_fasta,tmp_dir, min_length, logging, min_rpp_iden
            blast_results_file=blast_results, num_threads=num_threads, logging=logging)
 
     #return empty dataframe if no blast results generated
-    if os.path.getsize(blast_results) == 0:
+    if not os.path.isfile(blast_results) or os.path.getsize(blast_results) == 0:
         return {}
 
     df = BlastReader(blast_results, logging).df


### PR DESCRIPTION
When `blastn` produces empty results, it deletes the file: https://github.com/phac-nml/mob-suite/blob/6fa359789a04877cc6d7863f380f31816480b43a/mob_suite/utils.py#L344

However, the calling function, `blast_mge`, checks for an empty results file. When that file doesn't exist, it throws a file-not-found exception. This feels like a bug.

Instead, handle gracefully. An alternative approach would be to get the response from `blastn` (`True` or `False`) and use that. I don't know that either is necessarily better.