### PR TITLE
Add missing comma to entry_points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'Sequenoscope=Sequenoscope:main'
+            'Sequenoscope=Sequenoscope:main',
             'mob_init=mob_suite.mob_init:main',
             'mob_recon=mob_suite.mob_recon:main',
             'mob_cluster=mob_suite.mob_cluster:main',


### PR DESCRIPTION
`setup.py` is missing a comma on line 61 after the 'Sequenoscope=Sequenoscope:main' entry_point and causes parsing errors in the setup command. I am currently attempting to update this software's Bioconda recipe: [bioconda/bioconda-recipes#42131](https://github.com/bioconda/bioconda-recipes/pull/42131) and ran into this during the process.

This PR adds a comma on line 61 in `setup.py`, which fixes the parse error.